### PR TITLE
Breakout removePageListeners to allow manual cleanup

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -158,6 +158,20 @@ describe('PendingXHR', () => {
     });
   });
 
+  describe('removePageListeners', () => {
+    it('removes all listenners', async () => {
+      startServerReturning(OK_NO_XHR);
+      const page = await browser.newPage();
+      const count = page.listenerCount('request');
+      const pendingXHR = new PendingXHR(page);
+      await page.goto(`http://localhost:${port}/go`);
+      await pendingXHR.waitForAllXhrFinished();
+      expect(page.listenerCount('request')).toBe(count + 1);
+      pendingXHR.removePageListeners();
+      expect(page.listenerCount('request')).toBe(count);
+    });
+  });
+
   describe('waitOnceForAllXhrFinished', () => {
     it('returns and removes all listeners immediatly if no xhr pending', async () => {
       startServerReturning(OK_NO_XHR);

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,12 @@ export class PendingXHR {
     page.on('requestfinished', this.requestFinishedListener);
   }
 
+  removePageListeners() {
+    this.page.removeListener('request', this.requestListener);
+    this.page.removeListener('requestfailed', this.requestFailedListener);
+    this.page.removeListener('requestfinished', this.requestFinishedListener);
+  }
+
   async waitForAllXhrFinished() {
     if (this.pendingXhrCount() === 0) {
       return;
@@ -75,9 +81,7 @@ export class PendingXHR {
   async waitOnceForAllXhrFinished() {
     await this.waitForAllXhrFinished();
 
-    this.page.removeListener('request', this.requestListener);
-    this.page.removeListener('requestfailed', this.requestFailedListener);
-    this.page.removeListener('requestfinished', this.requestFinishedListener);
+    this.removePageListeners();
   }
 
   pendingXhrCount() {


### PR DESCRIPTION
The `waitOnceForAllXhrFinished` feature was a welcome addition, but in my use case we sometimes want to wait more than once on a page before removing the page listeners. This PR moves them to a class method that can be called on the `PendingXHR` instance manually.